### PR TITLE
Stub at simplifying L.CartoDBd3Layer

### DIFF
--- a/src/leaflet_d3.js
+++ b/src/leaflet_d3.js
@@ -75,10 +75,16 @@ L.CartoDBd3Layer = L.Class.extend({
       self.renderer.render(tile, geometry, tilePoint, self.provider.format);
     });
 
-    var tileSize = this._getTileSize();
-    var tilePos = this.tileLoader._getTilePos(tilePoint, tileSize);
-    tile.style.width = tile.style.height = tileSize + 'px';
+    var tilePos = this._getTilePos(tilePoint);
+    tile.style.width = tile.style.height = this._getTileSize() + 'px';
     L.DomUtil.setPosition(tile, tilePos, L.Browser.chrome);
+  },
+
+  _getTilePos: function (tilePoint) {
+    tilePoint = new L.Point(tilePoint.x, tilePoint.y);
+    var origin = this._map.getPixelOrigin();
+
+    return tilePoint.multiplyBy(this._getTileSize()).subtract(origin);
   },
 
   _getTileSize: function () {

--- a/src/leaflet_d3.js
+++ b/src/leaflet_d3.js
@@ -29,7 +29,7 @@ L.CartoDBd3Layer = L.Class.extend({
     else {
       this.provider = this.options.provider || new providers.SQLProvider(this.options);
     }
-    this.renderer = this.options.renderer || new Renderer({});
+    this.renderer = this.options.renderer || new Renderer(this.options);
 
     var tilePane = this._map._panes.tilePane;
     var layer = L.DomUtil.create('div', 'leaflet-layer');

--- a/src/leaflet_d3.js
+++ b/src/leaflet_d3.js
@@ -94,6 +94,11 @@ L.CartoDBd3Layer = L.Class.extend({
     return tileSize;
   },
 
+  // this.renderer is using this
+  latLngToLayerPoint: function(lat, lng){
+    return this._map.latLngToLayerPoint(new L.LatLng(lat,lng));
+  },
+
   setCartoCSS: function(cartocss){
     this.renderer.setCartoCSS(cartocss);
   }

--- a/src/leaflet_d3.js
+++ b/src/leaflet_d3.js
@@ -19,7 +19,6 @@ L.CartoDBd3Layer = L.Class.extend({
 
   onAdd: function (map) {
     this._map = map;
-    this.options.layer = this;
     if (this.options.urlTemplate || this.options.tilejson){
       this.provider = new providers.XYZProvider(this.options);
     }

--- a/src/leaflet_d3.js
+++ b/src/leaflet_d3.js
@@ -19,13 +19,17 @@ L.CartoDBd3Layer = L.Class.extend({
 
   onAdd: function (map) {
     this._map = map;
+
+    // TODO: Be more explicit about the options that providers and renderers need instead of
+    // passing the options of this object (this.options)
+    this.options.layer = this;
     if (this.options.urlTemplate || this.options.tilejson){
       this.provider = new providers.XYZProvider(this.options);
     }
     else {
       this.provider = this.options.provider || new providers.SQLProvider(this.options);
     }
-    this.renderer = this.options.renderer || new Renderer(this.options);
+    this.renderer = this.options.renderer || new Renderer({});
 
     var tilePane = this._map._panes.tilePane;
     var layer = L.DomUtil.create('div', 'leaflet-layer');
@@ -67,8 +71,8 @@ L.CartoDBd3Layer = L.Class.extend({
     tile.setAttribute("class", "leaflet-tile");
     this._container.appendChild(tile);
 
-    this.provider.getTile(tilePoint, function(tilePoint, geometry){
-      self.renderer.render(tile, geometry, tilePoint);
+    this.provider.getTile(tilePoint, function(tilePoint, geometry) {
+      self.renderer.render(tile, geometry, tilePoint, self.provider.format);
     });
 
     var tileSize = this._getTileSize();

--- a/src/providers/xyz.js
+++ b/src/providers/xyz.js
@@ -15,7 +15,7 @@ XYZProvider.prototype = {
     if (tileData) {
       callback(tilePoint, tileData);
     }
-    else{
+    else {
       if (!this.urlTemplate){
         this.urlTemplate = this.tilejson.tiles[0];
       }
@@ -26,7 +26,7 @@ XYZProvider.prototype = {
                 .replace("{s}", "abcd"[(tilePoint.x * tilePoint.y) % 4])
                 .replace(".png", ".geojson");
       this.getGeometry(url, function(err, geometry){
-        if(geometry.type === "Topology"){
+        if (geometry.type === "Topology"){
           self.format = "topojson";
           geometry = topojson.feature(geometry, geometry.objects.vectile);
         }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -153,7 +153,7 @@ Renderer.prototype = {
   },
   
 
-  render: function(svg, collection, tilePoint) {
+  render: function(svg, collection, tilePoint, format) {
     var self = this;
     this.currentPoint = tilePoint;
     var shader = this.shader;
@@ -172,7 +172,7 @@ Renderer.prototype = {
     var transform = d3.geo.transform({ 
       point: function(x, y) {
           // don't use leaflet projection since it's pretty slow
-          if(self.layer.provider.format === "topojson"){
+          if (format === "topojson"){
             var webm = geo.geo2Webmercator(x,y);
             x = webm.x, y = webm.y;
           }

--- a/src/tileloader.js
+++ b/src/tileloader.js
@@ -21,15 +21,7 @@ L.TileLoader = L.Class.extend({
     this._updateTiles();
   },
 
-  unbind: function() {
-    this._map.off({
-        'moveend': this._updateTiles
-    }, this);
-    this._removeTiles();
-  },
-
   _updateTiles: function () {
-
       if (!this._map) { return; }
 
       var bounds = this._map.getPixelBounds(),
@@ -52,68 +44,6 @@ L.TileLoader = L.Class.extend({
 
       this._addTilesFromCenterOut(tileBounds);
       this._removeOtherTiles(tileBounds);
-  },
-
-  _removeTiles: function (bounds) {
-      for (var key in this._tiles) {
-        this._removeTile(key);
-      }
-  },
-
-  _reloadTiles: function() {
-    this._removeTiles();
-    this._updateTiles();
-  },
-
-  _removeOtherTiles: function (bounds) {
-      var kArr, x, y, z, key;
-      var zoom = this._map.getZoom();
-
-      for (key in this._tiles) {
-          if (this._tiles.hasOwnProperty(key)) {
-              kArr = key.split(':');
-              x = parseInt(kArr[0], 10);
-              y = parseInt(kArr[1], 10);
-              z = parseInt(kArr[2], 10);
-
-              // remove tile if it's out of bounds
-              if (zoom !== z || x < bounds.min.x || x > bounds.max.x || y < bounds.min.y || y > bounds.max.y) {
-                  this._removeTile(key);
-              }
-          }
-      }
-  },
-
-  _removeTile: function (key) {
-      this.fire('tileRemoved', this._tiles[key]);
-      delete this._tiles[key];
-      delete this._tilesLoading[key];
-  },
-
-  _tileKey: function(tilePoint) {
-    return tilePoint.x + ':' + tilePoint.y + ':' + tilePoint.zoom;
-  },
-
-  _tileShouldBeLoaded: function (tilePoint) {
-      var k = this._tileKey(tilePoint);
-      return !(k in this._tiles) && !(k in this._tilesLoading);
-  },
-
-  _tileLoaded: function(tilePoint, tileData) {
-    this._tilesToLoad--;
-    var k = tilePoint.x + ':' + tilePoint.y + ':' + tilePoint.zoom;
-    this._tiles[k] = tileData;
-    delete this._tilesLoading[k];
-    if(this._tilesToLoad === 0) {
-      this.fire("tilesLoaded");
-    }
-  },
-
-  _getTilePos: function (tilePoint, tileSize) {
-    tilePoint = new L.Point(tilePoint.x, tilePoint.y);
-    var origin = this._map.getPixelOrigin();
-
-    return tilePoint.multiplyBy(tileSize).subtract(origin);
   },
 
   _addTilesFromCenterOut: function (bounds) {
@@ -152,7 +82,53 @@ L.TileLoader = L.Class.extend({
         this.fire('tileAdded', t);
       }
       this.fire("tilesLoading");
+  },
 
+  _removeOtherTiles: function (bounds) {
+      var kArr, x, y, z, key;
+      var zoom = this._map.getZoom();
+
+      for (key in this._tiles) {
+          if (this._tiles.hasOwnProperty(key)) {
+              kArr = key.split(':');
+              x = parseInt(kArr[0], 10);
+              y = parseInt(kArr[1], 10);
+              z = parseInt(kArr[2], 10);
+
+              // remove tile if it's out of bounds
+              if (zoom !== z || x < bounds.min.x || x > bounds.max.x || y < bounds.min.y || y > bounds.max.y) {
+                  this._removeTile(key);
+              }
+          }
+      }
+  },
+
+  unbind: function() {
+    this._map.off({
+        'moveend': this._updateTiles
+    }, this);
+    this._removeTiles();
+  },
+
+
+  _removeTiles: function (bounds) {
+    for (var key in this._tiles) {
+      this._removeTile(key);
+    }
+  },
+
+  _removeTile: function (key) {
+    this.fire('tileRemoved', this._tiles[key]);
+    delete this._tiles[key];
+    delete this._tilesLoading[key];
+  },
+
+  _tileKey: function(tilePoint) {
+    return tilePoint.x + ':' + tilePoint.y + ':' + tilePoint.zoom;
+  },
+
+  _tileShouldBeLoaded: function (tilePoint) {
+      var k = this._tileKey(tilePoint);
+      return !(k in this._tiles) && !(k in this._tilesLoading);
   }
-
 });

--- a/src/tileloader.js
+++ b/src/tileloader.js
@@ -1,16 +1,27 @@
-L.Mixin.TileLoader = {
+L.TileLoader = L.Class.extend({
 
-  _initTileLoader: function() {
+  includes: L.Mixin.Events,
+
+  initialize: function(options) {
+    this.options = options;
+  },
+
+  getTile: function(tilePoint) {
+    return this._tiles[tilePoint.zoom + ":" + tilePoint.x + ":" + tilePoint.y];
+  },
+
+  bind: function(map) {
+    this._map = map;
     this._tiles = {};
     this._tilesLoading = {};
     this._tilesToLoad = 0;
     this._map.on({
-        'moveend': this._updateTiles
+      'moveend': this._updateTiles
     }, this);
     this._updateTiles();
   },
 
-  _removeTileLoader: function() {
+  unbind: function() {
     this._map.off({
         'moveend': this._updateTiles
     }, this);
@@ -98,10 +109,9 @@ L.Mixin.TileLoader = {
     }
   },
 
-  _getTilePos: function (tilePoint) {
+  _getTilePos: function (tilePoint, tileSize) {
     tilePoint = new L.Point(tilePoint.x, tilePoint.y);
-    var origin = this._map.getPixelOrigin(),
-        tileSize = this._getTileSize();
+    var origin = this._map.getPixelOrigin();
 
     return tilePoint.multiplyBy(tileSize).subtract(origin);
   },
@@ -145,4 +155,4 @@ L.Mixin.TileLoader = {
 
   }
 
-};
+});


### PR DESCRIPTION
I'm exploring this code, and had some ideas to make it a bit simpler. Here are some of the things I did:
- TileLoader is no longer a mixing, but a real class.
- L.CartoDBd3Layer inherits from L.Class instead instead of L.TileLayer.
- Instances of L.CartoDBd3Layer have an instance of TileLoader.

What I'm thinking is that we might need to extract the TileLoader and the providers from Views so that other components in CartoDB.js can use them. For example, widgets will need to to generate stats from some geojson that the TileLoader have cached...

@fdansv thoughts? Not sure if we should merge this now, since it's a POC. I just wanted to share it git you to get some feedback. Thanks!
