### PR TITLE
Enables user/table initialising through the maps API instead of SQL

### DIFF
--- a/src/leaflet_d3.js
+++ b/src/leaflet_d3.js
@@ -35,7 +35,7 @@ L.CartoDBd3Layer = L.Class.extend({
       this.provider = new providers.XYZProvider(this.options);
     }
     else {
-      this.provider = this.options.provider || new providers.SQLProvider(this.options);
+      this.provider = this.options.provider || new providers.WindshaftProvider(this.options);
     }
     this.renderer = this.options.renderer || new Renderer(this.options);
 

--- a/src/leaflet_d3.js
+++ b/src/leaflet_d3.js
@@ -32,15 +32,16 @@ L.CartoDBd3Layer = L.TileLayer.extend({
     this._map = map;
     this.options.map = map;
     this.options.layer = this;
+    var styles = this.options.styles;
+    if(!styles){
+      styles = [this.options.cartocss];
+      this.options.styles = styles;
+    }
     if (this.options.urlTemplate || this.options.tilejson){
       this.provider = new providers.XYZProvider(this.options);
     }
     else {
       this.provider = this.options.provider || new providers.WindshaftProvider(this.options);
-    }
-    var styles = this.options.styles;
-    if(!styles){
-      styles = [this.options.cartocss];
     }
     for (var i = 0; i < styles.length; i++){
       this.renderers.push(new Renderer({cartocss: styles[i],

--- a/src/providers/windshaft.js
+++ b/src/providers/windshaft.js
@@ -1,13 +1,78 @@
 var d3 = require("d3");
+var _ = require("underscore");
+var Providers = require("./");
 
 function WindshaftProvider(options) {
-	this.sql_api_template = options.sql_api_template || 'http://{user}.cartodb.com';
+	this.tiler_template = options.tiler_template || 'http://{user}.cartodb.com';
 	this.user = options.user;
 	this.table = options.table;
 	this.format = options.format;
+	this.options = options;
 	this.tileCache = {};
+	this.initialize();
 }
 
 WindshaftProvider.prototype = {
+	initialize: function(){
+		var self = this;
+		this.tiler_template = this.tiler_template.replace("{user}", this.user);
+		var mapconfig = this._generateMapconfig(this.table);
+		var url = this.tiler_template + "/api/v1/map?config=" + encodeURIComponent(JSON.stringify(mapconfig));
+		cartodb.d3.net.jsonp(url + "&callback=mapconfig", function(data){
+			self.layergroup = data;
+			self.urlTemplate = self.tiler_template + "/api/v1/map/" + self.layergroup.layergroupid+"/0/{z}/{x}/{y}.geojson"
+			self.options.layer._reloadTiles();
+		});
+	},
 
+	getTile: function(tilePoint, callback){
+		if(this.layergroup){
+	    var self = this;
+	    var tileData = this.tileCache[tilePoint.zoom + ":" + tilePoint.x + ":" + tilePoint.y];
+	    if (tileData) {
+	      callback(tilePoint, tileData);
+	    }
+	    else{
+	      var url = this.urlTemplate
+	                .replace("{x}", tilePoint.x)
+	                .replace("{y}", tilePoint.y)
+	                .replace("{z}", tilePoint.zoom);
+	      this.getGeometry(url, function(err, geometry){
+	        if(geometry.type === "Topology"){
+	          self.format = "topojson";
+	          geometry = topojson.feature(geometry, geometry.objects.vectile);
+	        }
+	        this.tileCache[tilePoint.zoom + ":" + tilePoint.x + ":" + tilePoint.y] = geometry;
+	        callback(tilePoint, geometry);
+	      }.bind(this));
+	    }
+	  }
+  },
+
+  getGeometry: function(url, callback){
+      d3.json(url, callback);
+  },
+
+	_generateMapconfig: function(table) {
+		var mapconfig = {
+		  "version": "1.0.1",
+		  "layers": [
+		    {
+		      "type": "cartodb",
+		      "options": {
+		        "sql": "select * from " + table,
+		        "cartocss": this.options.styles[0],
+		        "cartocss_version": "2.1.1"
+		      }
+		    }
+		  ]
+		}
+		return mapconfig;
+	},
+
+  invalidateCache: function(){
+    this.tileCache = {};
+  }
 };
+
+module.exports = WindshaftProvider;

--- a/src/tileloader.js
+++ b/src/tileloader.js
@@ -118,9 +118,9 @@ L.Mixin.TileLoader = {
               point = new L.Point(i, j);
               point.zoom =  zoom;
 
-              if (this._tileShouldBeLoaded(point)) {
+              // if (this._tileShouldBeLoaded(point)) {
                   queue.push(point);
-              }
+              // }
           }
       }
 


### PR DESCRIPTION
For standalone use only, as querying the layergroup is cartodb.js's job. This just allows us to make a map by specifying a user and a table, without using the SQL API as it has been the case so far.
Needs polishing, adding tests
