### PR TITLE
Allows rendering out of regular coordinate bounds

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -179,7 +179,9 @@ Renderer.prototype = {
         var pixelScale = 256 * (1 << tilePoint.zoom)
         x = pixelScale * (x + earthRadius2) * invEarth
         y = pixelScale * (-y + earthRadius2) * invEarth
-        this.stream.point(x - self.currentPoint.x * 256, y - self.currentPoint.y * 256)
+        var limit_x = Math.pow(2, self.currentPoint.zoom)
+        var corrected_x = ((tilePoint.x % limit_x) + limit_x) % limit_x
+        this.stream.point(x - corrected_x * 256, y - self.currentPoint.y * 256)
       }
     })
     var path = d3.geo.path().projection(transform)


### PR DESCRIPTION
Super quick fix @rochoa 
![bounds](https://cloud.githubusercontent.com/assets/3707222/11953684/619f7a0c-a8a2-11e5-9de6-62cca60b33cd.gif)
