### PR TITLE
Enables selection of cross-tile polygons without stitching

### DIFF
--- a/src/providers/windshaft.js
+++ b/src/providers/windshaft.js
@@ -56,8 +56,9 @@ WindshaftProvider.prototype = {
   },
 
   _processQueue: function () {
+    var self = this
     this._tileQueue.forEach(function (item) {
-      this.getTile.apply(this, item)
+      self.getTile.apply(self, item)
     })
   },
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -69,7 +69,9 @@ Renderer.prototype = {
       case 'featureOver':
         this.events.featureOver = function (f) {
           this.style.cursor = 'pointer'
-          callback(d3.select(this).data()[0], d3.select(this))
+          self.geometries[f.properties.cartodb_id].forEach(function (feature) {
+            callback(d3.select(feature).data()[0], d3.select(feature))
+          })
         }
         break
       case 'featureOut':
@@ -220,17 +222,23 @@ Renderer.prototype = {
     var self = this
     features.each(function (d) {
       if (!d.properties) d.properties = {}
+      if (!self.geometries[d.properties.cartodb_id]) self.geometries[d.properties.cartodb_id] = []
+      self.geometries[d.properties.cartodb_id].push(this)
       d.properties.global = self.globalVariables
       d.shader = layer.getStyle(d.properties, {zoom: group.tilePoint.zoom, time: self.time})
       if (layer.hover) {
         d.shader_hover = layer.hover.getStyle(d.properties, { zoom: group.tilePoint.zoom, time: self.time })
         _.defaults(d.shader_hover, d.shader)
-        self.events.featureOver = function () {
+        self.events.featureOver = function (f) {
           this.style.cursor = 'default'
-          d3.select(this).style(self.styleForSymbolizer(sym, 'shader_hover'))
+          self.geometries[d3.select(this).data()[0].properties.cartodb_id].forEach(function (feature) {
+            d3.select(feature).style(self.styleForSymbolizer(sym, 'shader_hover'))
+          })
         }
         self.events.featureOut = function () {
-          d3.select(this).style(self.styleForSymbolizer(sym, 'shader'))
+          self.geometries[d3.select(this).data()[0].properties.cartodb_id].forEach(function (feature) {
+            d3.select(feature).style(self.styleForSymbolizer(sym, 'shader'))
+          })
         }
       }
     })


### PR DESCRIPTION
Before:
![before](https://cloud.githubusercontent.com/assets/3707222/11974442/9dea9bbe-a964-11e5-8634-306f8221010f.gif)
After:
![after](https://cloud.githubusercontent.com/assets/3707222/11974445/a408cba6-a964-11e5-9e8a-7e2f26535595.gif)

cc @rochoa @javisantana 
