### PR TITLE
Cancels pending tile loads when zoom is changed

### DIFF
--- a/src/leaflet_d3.js
+++ b/src/leaflet_d3.js
@@ -242,12 +242,6 @@ L.CartoDBd3Layer = L.TileLayer.extend({
     this.tileLoader._tilesLoading = {}
     for (i = 0, len = tiles.length; i < len; i++) {
       tile = tiles[i]
-
-      if (!tile.complete) {
-        tile.onload = L.Util.falseFn
-        tile.onerror = L.Util.falseFn
-        tile.src = L.Util.emptyImageUrl
-      }
       tile.parentNode.removeChild(tile)
     }
     for (var tileKey in this.provider.requests){

--- a/src/leaflet_d3.js
+++ b/src/leaflet_d3.js
@@ -244,9 +244,6 @@ L.CartoDBd3Layer = L.TileLayer.extend({
       tile = tiles[i]
       tile.parentNode.removeChild(tile)
     }
-    for (var tileKey in this.provider.requests){
-      this.provider.requests[tileKey].abort()
-    }
-    this.provider.requests = {}
+    this.provider.abortPending()
   }
 })

--- a/src/leaflet_d3.js
+++ b/src/leaflet_d3.js
@@ -250,5 +250,9 @@ L.CartoDBd3Layer = L.TileLayer.extend({
       }
       tile.parentNode.removeChild(tile)
     }
+    for (var tileKey in this.provider.requests){
+      this.provider.requests[tileKey].abort()
+    }
+    this.provider.requests = {}
   }
 })

--- a/src/providers/windshaft.js
+++ b/src/providers/windshaft.js
@@ -10,6 +10,7 @@ function WindshaftProvider (options) {
   this._tileQueue = []
   this.initialize()
   this._ready = false
+  this.requests = {}
 }
 
 cartodb.d3.extend(WindshaftProvider.prototype, cartodb.d3.Event, {
@@ -29,6 +30,8 @@ cartodb.d3.extend(WindshaftProvider.prototype, cartodb.d3.Event, {
   getTile: XYZProvider.prototype.getTile,
 
   getGeometry: XYZProvider.prototype.getGeometry,
+
+  abortPending: XYZProvider.prototype.abortPending,
 
   _generateMapconfig: function (table) {
     var mapconfig = {

--- a/src/providers/xyz.js
+++ b/src/providers/xyz.js
@@ -8,6 +8,7 @@ function XYZProvider (options) {
   this.tilejson = options.tilejson
   this._tileQueue = []
   this._ready = false
+  this.requests = {}
   if (!this.urlTemplate) {
     if (this.tilejson) {
       this.urlTemplate = this.tilejson.tiles[0]
@@ -44,7 +45,7 @@ cartodb.d3.extend(XYZProvider.prototype, cartodb.d3.Event, {
       .replace('{s}', 'abcd'[(tilePoint.x * tilePoint.y) % 4])
       .replace('.png', '.geojson')
 
-    d3.json(url, callback)
+    this.requests[[tilePoint.x, tilePoint.y, tilePoint.zoom].join(':')] = d3.json(url, callback)
   },
 
   _setReady: function () {

--- a/src/providers/xyz.js
+++ b/src/providers/xyz.js
@@ -61,6 +61,13 @@ cartodb.d3.extend(XYZProvider.prototype, cartodb.d3.Event, {
     this._setReady()
   },
 
+  abortPending: function () {
+    for (var tileKey in this.requests) {
+      this.requests[tileKey].abort()
+    }
+    this.requests = {}
+  },
+
   _processQueue: function () {
     var self = this
     this._tileQueue.forEach(function (item) {


### PR DESCRIPTION
The library was wrongly using code that applied to `<img>` tags but not really to svg generated with d3 requests. This also corrects a bug that renders tiles with the wrong zoom level.

@alonsogarciapablo 
