### PR TITLE
Won't return features with repeated IDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ clean:
 test: lint
 	./node_modules/.bin/karma start --single-run --browsers Firefox
 
-testDebug: lint
+testDebug:
 	./node_modules/karma/bin/karma start
 
 lint:

--- a/spec/filter.spec.js
+++ b/spec/filter.spec.js
@@ -79,8 +79,8 @@ describe('The filter', function () {
   })
 
   it ('shouldn\'t return more than one feature with the same cartodb_id', function () {
-    dump(this.filter.getValues().length)
+    var initialLength = this.filter.getValues().length
     this.filter.addTile({x: 2, y: 1, zoom: 3}, this.tile)
-    dump(this.filter.getValues().length)
+    expect(initialLength).toEqual(this.filter.getValues().length)
   })
 })

--- a/spec/filter.spec.js
+++ b/spec/filter.spec.js
@@ -78,4 +78,9 @@ describe('The filter', function () {
     expect(this.filter.crossfilter.size() === 15).toBe(true)
   })
 
+  it ('shouldn\'t return more than one feature with the same cartodb_id', function () {
+    dump(this.filter.getValues().length)
+    this.filter.addTile({x: 2, y: 1, zoom: 3}, this.tile)
+    dump(this.filter.getValues().length)
+  })
 })

--- a/src/filter.js
+++ b/src/filter.js
@@ -76,7 +76,7 @@ cartodb.d3.extend(Filter.prototype, cartodb.d3.Event, {
     this.fire('filterApplied')
   },
 
-  getValues: function (ownFilter, column, uniques) {
+  getValues: function (ownFilter, column) {
     if (!this.dimensions['tiles']) return []
     var values = []
     if (typeof ownFilter === 'undefined' || ownFilter){
@@ -87,7 +87,6 @@ cartodb.d3.extend(Filter.prototype, cartodb.d3.Event, {
       this.dimensions[column].filterAll()
       var values = this.dimensions[column].top(Infinity)
       this.dimensions[column].filter(this.filters[column])
-      values = values
     }
     var uniqueValues = []
     var ids = {}
@@ -97,8 +96,7 @@ cartodb.d3.extend(Filter.prototype, cartodb.d3.Event, {
         ids[values[i].properties.cartodb_id] = true
       }
     }
-    values = uniqueValues
-    return values
+    return uniqueValues
   },
 
   getColumnValues: function (column, numberOfValues) {

--- a/src/filter.js
+++ b/src/filter.js
@@ -85,7 +85,7 @@ cartodb.d3.extend(Filter.prototype, cartodb.d3.Event, {
     var ids = {}
     for (var i = 0; i < values.length; i++) {
       if (!(values[i].properties.cartodb_id in ids)) {
-        uniqueValues += values[i]
+        uniqueValues.push(values[i])
         ids[values[i].properties.cartodb_id] = true
       }
     }

--- a/src/filter.js
+++ b/src/filter.js
@@ -73,7 +73,16 @@ Filter.prototype = {
   },
 
   getValues: function (column) {
-    return this.dimensions[column].top(Infinity)
+    var values = this.dimensions[column].top(Infinity)
+    var uniqueValues = []
+    var ids = {}
+    for (var i = 0; i < values.length; i++) {
+      if (!(values[i].properties.cartodb_id in ids)) {
+        uniqueValues += values[i]
+        ids[values[i].properties.cartodb_id] = true
+      }
+    }
+    return uniqueValues
   },
 
   setBoundingBox: function (north, east, south, west) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 module.exports.d3 = require('./core')
 require('./leaflet_d3.js')
 var elements = {
-	Layer: require('./leaflet_d3.js'),
   Util: require('./util.js'),
   geo: require('./geo.js'),
   Renderer: require('./renderer.js'),


### PR DESCRIPTION
This fixes #61. Widget data will not be tainted by repeated features. This is especially relevant for polygon and line datasets.

@alonsogarciapablo 
