### PR TITLE
Export Leaflet layer so that CartoDB.js can use it via browserify

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,13 @@
+var LeafletCartoDBd3Layer = require('./leaflet_d3.js')
+module.exports = {
+  Leaflet = {
+    CartoDBd3Layer: LeafletCartoDBd3Layer
+  }
+}
+
+// TODO: There's no need to export all the modules below
+// right now, so we should remove them from here.
 module.exports.d3 = require('./core')
-require('./leaflet_d3.js')
 var elements = {
   Util: require('./util.js'),
   geo: require('./geo.js'),

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 var LeafletCartoDBd3Layer = require('./leaflet_d3.js')
 module.exports = {
-  Leaflet = {
+  Leaflet: {
     CartoDBd3Layer: LeafletCartoDBd3Layer
   }
 }

--- a/src/leaflet_d3.js
+++ b/src/leaflet_d3.js
@@ -286,3 +286,6 @@ L.CartoDBd3Layer = L.TileLayer.extend({
     this.provider.abortPending()
   }
 })
+
+module.exports = L.CartoDBd3Layer
+


### PR DESCRIPTION
@fdansv this allows me to do things like:

```
var D3CartoDB = require('d3.cartodb');
var LeafletCartoDBd3Layer = D3CartoDB.Leaflet.CartoDBd3Layer;
var MyLayer = LeafletCartoDBd3Layer.extend({ ... });
```
