### PR TITLE
Returns data exclusively from visible tiles

### DIFF
--- a/src/filter.js
+++ b/src/filter.js
@@ -97,6 +97,13 @@ cartodb.d3.extend(Filter.prototype, cartodb.d3.Event, {
         ids[values[i].properties.cartodb_id] = true
       }
     }
+    var boundingBox = this.tilesWithin
+    if (this.tilesWithin.length > 0) {
+      uniqueValues = uniqueValues.filter(function(feature){
+        return boundingBox.indexOf(feature.properties.tilePoint) > -1
+      })
+    }
+
     return uniqueValues
   },
 

--- a/src/filter.js
+++ b/src/filter.js
@@ -106,10 +106,7 @@ cartodb.d3.extend(Filter.prototype, cartodb.d3.Event, {
 
 
   setBoundingBox: function (tiles) {
-    if (!this.dimensions.bbox) {
-      this.dimensions.bbox = this.crossfilter.dimension(function (f) { return f.properties.tilePoint })
-    }
-    this.dimensions.bbox.filter(function (g) {
+    this.dimensions.tiles.filter(function (g) {
       return this.indexOf(g) > -1
     }.bind(tiles))
     this.fire('filterApplied')

--- a/src/filter.js
+++ b/src/filter.js
@@ -119,6 +119,7 @@ cartodb.d3.extend(Filter.prototype, cartodb.d3.Event, {
         g.coordinates[1] > south &&
         g.coordinates[0] > west
     }.bind(arguments))
+    this.fire('filterApplied')
   },
 
   getMax: function (column) { 

--- a/src/filter.js
+++ b/src/filter.js
@@ -11,10 +11,10 @@ function Filter () {
 
 cartodb.d3.extend(Filter.prototype, cartodb.d3.Event, {
   addTile: function (tilePoint, collection) {
-    var tilePointString = tilePoint.zoom + ':' + tilePoint.x + ':' + tilePoint.y
+    var tilePointString = tilePoint.x + ':' + tilePoint.y + ':' + tilePoint.zoom
     if (typeof this.tiles[tilePointString] !== 'undefined') return this.getTile(tilePoint)
     this.crossfilter.add(collection.features.map(function (f) {
-      f.properties.tilePoint = tilePoint.zoom + ':' + tilePoint.x + ':' + tilePoint.y
+      f.properties.tilePoint = tilePoint.x + ':' + tilePoint.y + ':' + tilePoint.zoom
       return f
     }))
     this.tiles[tilePointString] = true
@@ -22,7 +22,7 @@ cartodb.d3.extend(Filter.prototype, cartodb.d3.Event, {
   },
 
   removeTile: function (tilePoint) {
-    var tilePointString = tilePoint.zoom + ':' + tilePoint.x + ':' + tilePoint.y
+    var tilePointString = tilePoint.x + ':' + tilePoint.y + ':' + tilePoint.zoom
     if (!this.dimensions.tiles) {
       return
     }
@@ -33,7 +33,7 @@ cartodb.d3.extend(Filter.prototype, cartodb.d3.Event, {
   },
 
   getTile: function (tilePoint) {
-    var tilePointString = tilePoint.zoom + ':' + tilePoint.x + ':' + tilePoint.y
+    var tilePointString = tilePoint.x + ':' + tilePoint.y + ':' + tilePoint.zoom
     if (!this.dimensions.tiles) {
       this.dimensions.tiles = this.crossfilter.dimension(function (f) { return f.properties.tilePoint })
     }

--- a/src/filter.js
+++ b/src/filter.js
@@ -108,17 +108,17 @@ cartodb.d3.extend(Filter.prototype, cartodb.d3.Event, {
   setBoundingBox: function (north, east, south, west) {
     if (!this.dimensions.bbox) {
       this.dimensions.bbox = this.crossfilter.dimension(function (f) { return f.geometry })
-      this.dimensions.bbox.filter(function (g) {
-        var north = this[0]
-        var east = this[1]
-        var south = this[2]
-        var west = this[3]
-        return g.coordinates[1] < north &&
+    }
+    this.dimensions.bbox.filter(function (g) {
+      var north = this[0]
+      var east = this[1]
+      var south = this[2]
+      var west = this[3]
+      return g.coordinates[1] < north &&
         g.coordinates[0] < east &&
         g.coordinates[1] > south &&
         g.coordinates[0] > west
-      }.bind(arguments))
-    }
+    }.bind(arguments))
   },
 
   getMax: function (column) { 

--- a/src/filter.js
+++ b/src/filter.js
@@ -5,6 +5,7 @@ function Filter () {
   this.crossfilter = new Crossfilter()
   this.dimensions = {}
   this.tiles = {}
+  this.tilesWithin = []
   this.filters = {}
 }
 

--- a/src/filter.js
+++ b/src/filter.js
@@ -105,20 +105,13 @@ cartodb.d3.extend(Filter.prototype, cartodb.d3.Event, {
   },
 
 
-  setBoundingBox: function (north, east, south, west) {
+  setBoundingBox: function (tiles) {
     if (!this.dimensions.bbox) {
-      this.dimensions.bbox = this.crossfilter.dimension(function (f) { return f.geometry })
+      this.dimensions.bbox = this.crossfilter.dimension(function (f) { return f.properties.tilePoint })
     }
     this.dimensions.bbox.filter(function (g) {
-      var north = this[0]
-      var east = this[1]
-      var south = this[2]
-      var west = this[3]
-      return g.coordinates[1] < north &&
-        g.coordinates[0] < east &&
-        g.coordinates[1] > south &&
-        g.coordinates[0] > west
-    }.bind(arguments))
+      return this.indexOf(g) > -1
+    }.bind(tiles))
     this.fire('filterApplied')
   },
 

--- a/src/filter.js
+++ b/src/filter.js
@@ -107,10 +107,7 @@ cartodb.d3.extend(Filter.prototype, cartodb.d3.Event, {
 
 
   setBoundingBox: function (tiles) {
-    this.dimensions.tiles.filter(function (g) {
-      return this.indexOf(g) > -1
-    }.bind(tiles))
-    this.fire('filterApplied')
+    this.tilesWithin = tiles
   },
 
   getMax: function (column) { 

--- a/src/geo.js
+++ b/src/geo.js
@@ -26,5 +26,13 @@ module.exports = {
   hashFeature: function (id, tilePoint) {
     var pane = Math.floor(tilePoint.x / Math.pow(2, tilePoint.zoom))
     return [id, pane].join(':')
+  },
+  lng2tile: function (lon,zoom) { return (Math.floor((lon+180)/360*Math.pow(2,zoom))); },
+  lat2tile: function (lat,zoom) { return (Math.floor((1-Math.log(Math.tan(lat*Math.PI/180) + 1/Math.cos(lat*Math.PI/180))/Math.PI)/2 *Math.pow(2,zoom))); },
+
+  latLng2Tile: function (lat, lng, zoom) {
+    return {x: this.lng2tile(lng, zoom),
+            y: this.lat2tile(lat, zoom),
+            zoom: zoom}
   }
 }

--- a/src/leaflet_d3.js
+++ b/src/leaflet_d3.js
@@ -40,6 +40,20 @@ L.CartoDBd3Layer = L.TileLayer.extend({
     }
   },
 
+  _getVisibleTiles: function () {
+    var bounds = this._map.getBounds()
+    var zoom = this._map.getZoom()
+    var nwTile = geo.latLng2Tile(bounds.getNorthWest().lat, bounds.getNorthWest().lng, zoom)
+    var seTile = geo.latLng2Tile(bounds.getSouthEast().lat, bounds.getSouthEast().lng, zoom)
+    var tiles = []
+    for(var y = nwTile.y; y<=seTile.y; y++) {
+      for(var x = nwTile.x; x<=seTile.x; x++) {
+        tiles.push([x,y,zoom].join(':'))
+      }
+    }
+    return tiles
+  },
+
   applyFilter: function (sublayerIndex, filterType, filterOptions) {
     var sublayer = this.renderers[sublayerIndex]
     switch (filterType) {

--- a/src/leaflet_d3.js
+++ b/src/leaflet_d3.js
@@ -139,11 +139,9 @@ L.CartoDBd3Layer = L.TileLayer.extend({
   },
 
   _setBoundingBox: function () {
-    var bounds = this._map.getBounds()
+    var tiles = this._getVisibleTiles()
     this.renderers.forEach(function (renderer) {
-      var ne = geo.geo2Webmercator(bounds._northEast.lng, bounds._northEast.lat)
-      var sw = geo.geo2Webmercator(bounds._southWest.lng, bounds._southWest.lat)
-      renderer.filter.setBoundingBox(ne.y, ne.x, sw.y, sw.x)
+      renderer.filter.setBoundingBox(tiles)
       renderer.redraw()
     })
   },

--- a/src/leaflet_d3.js
+++ b/src/leaflet_d3.js
@@ -142,7 +142,6 @@ L.CartoDBd3Layer = L.TileLayer.extend({
     var tiles = this._getVisibleTiles()
     this.renderers.forEach(function (renderer) {
       renderer.filter.setBoundingBox(tiles)
-      renderer.redraw()
     })
   },
 

--- a/src/tileloader.js
+++ b/src/tileloader.js
@@ -13,12 +13,12 @@ module.exports = L.Class.extend({
     this._tilesToLoad = 0
     this.lastDrag = 0
     this._map.on('moveend', this._reloadTiles, this)
-    this._map.on('drag', function () {
-      if ((this.dragging._lastTime - self.lastDrag) > 500) {
-        self.lastDrag = this.dragging._lastTime
-        self._reloadTiles()
-      }
-    })
+    // this._map.on('drag', function () {
+    //   if ((this.dragging._lastTime - self.lastDrag) > 500) {
+    //     self.lastDrag = this.dragging._lastTime
+    //     self._reloadTiles()
+    //   }
+    // })
   },
 
   loadTiles: function () {


### PR DESCRIPTION
Fixes #98 partially.

Why partially? Features in tiles that are cut by the map bounds are still counted for filtering purposes. We need a more detailed method to filter by bounding box, but for now this excludes tiles that have been cached from other areas of the map, and tiles that leaflet downloads as buffers (the "outer ring" of tiles that is never visible but that until now have been counted in crossfilter).

cc @alonsogarciapablo 
