### PR TITLE
Checks that there are coordinates and calculates the projection only once for each point

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -276,11 +276,12 @@ Renderer.prototype = {
       features = this._transformText(features)
     } else if (sym === 'markers') {
       features.enter().append('circle').attr('class', sym)
-      features.attr('cx', function (f) {
-        return self.projection.apply(this, f.coordinates).x
-      })
-      features.attr('cy', function (f) {
-        return self.projection.apply(this, f.coordinates).y
+      features.each(function(f) {
+        if (f.coordinates[0]){
+          var coords = self.projection.apply(this, f.coordinates)
+          this.setAttribute('cx', coords.x)
+          this.setAttribute('cy', coords.y)
+        }
       })
     } else {
       features.enter().append('path').attr('class', sym)


### PR DESCRIPTION
Solves #102 (at least in this library, it doesn't solve https://github.com/CartoDB/Windshaft/issues/435). It also increases performance as it's making half the projection calculations it used to.
