### PR TITLE
Won't render element if it doesn't have coordinates associated

### DIFF
--- a/src/filter.js
+++ b/src/filter.js
@@ -102,7 +102,7 @@ cartodb.d3.extend(Filter.prototype, cartodb.d3.Event, {
     if (boundingBox) {
       uniqueValues = uniqueValues.filter(function(feature) {
         if (boundingBox.indexOf(feature.properties.tilePoint) > -1) return true
-        else if (ring.indexOf(feature.properties.tilePoint) > -1) {
+        else if (feature.geometry.coordinates && ring.indexOf(feature.properties.tilePoint) > -1) {
           if (this.visibleTiles.se.x >= feature.geometry.coordinates[0] &&
               feature.geometry.coordinates[0] >= this.visibleTiles.nw.x && 
               this.visibleTiles.se.y <= feature.geometry.coordinates[1] &&

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -282,6 +282,9 @@ Renderer.prototype = {
           this.setAttribute('cx', coords.x)
           this.setAttribute('cy', coords.y)
         }
+        else{
+          this.parentElement.removeChild(this)
+        }
       })
     } else {
       features.enter().append('path').attr('class', sym)


### PR DESCRIPTION
This is a patch to deal with empty `GeometryCollection` elements coming from the tiler. The root of the problem is https://github.com/CartoDB/Windshaft/issues/435
