### PR TITLE
Take into account the map container when calculating the latlng and pos of mouse events

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -72,8 +72,9 @@ Renderer.prototype = {
         this.style.cursor = 'pointer'
         var properties = selection.data()[0].properties
         var index = Renderer.getIndexFromFeature(this)
-        var latLng = self.layer._map.layerPointToLatLng([f.clientX, f.clientY])
-        self.layer.eventCallbacks.featureOver(f, [latLng.lat, latLng.lng], {x: f.clientX, y: f.clientY}, properties, index)
+        var latLng = self._getLatLngFromEvent(self.layer._map, f)
+        var pos = self._getPosFromEvent(self.layer._map, f)
+        self.layer.eventCallbacks.featureOver(f, latLng, pos, properties, index)
       }
     } else if (eventName ==='featureOut') {
       this.events.featureOut = function (f) {
@@ -83,18 +84,38 @@ Renderer.prototype = {
           selection.style(self.styleForSymbolizer(sym, 'shader'))
         }
         var index = Renderer.getIndexFromFeature(this)
-        var latLng = self.layer._map.layerPointToLatLng([f.clientX, f.clientY])
-        self.layer.eventCallbacks.featureOut(f, [latLng.lat, latLng.lng], {x: f.clientX, y: f.clientY}, d3.select(this).data()[0].properties, index)
+        var latLng = self._getLatLngFromEvent(self.layer._map, f)
+        var pos = self._getPosFromEvent(self.layer._map, f)
+        self.layer.eventCallbacks.featureOut(f, latLng, pos, d3.select(this).data()[0].properties, index)
       }
     } else if (eventName ==='featureClick') {
       this.events.featureClick = function (f) {
         var index = Renderer.getIndexFromFeature(this)
-        var latLng = self.layer._map.layerPointToLatLng([f.clientX, f.clientY])
-        self.layer.eventCallbacks.featureClick(f, [latLng.lat, latLng.lng], {x: f.clientX, y: f.clientY}, d3.select(this).data()[0].properties, index)
+        var latLng = self._getLatLngFromEvent(self.layer._map, f)
+        var pos = self._getPosFromEvent(self.layer._map, f)
+        self.layer.eventCallbacks.featureClick(f, latLng, pos, d3.select(this).data()[0].properties, index)
       }
     } else if (eventName ==='featuresChanged') {
       this.filter.on('featuresChanged', callback)
     }
+  },
+
+  _getLatLngFromEvent: function (map, mouseEvent) {
+    var mapBoundingBoxClientRect = map.getContainer().getBoundingClientRect()
+    var latLng = map.layerPointToLatLng([
+      mouseEvent.clientX - mapBoundingBoxClientRect.left,
+      mouseEvent.clientY - mapBoundingBoxClientRect.top
+    ]);
+
+    return [latLng.lat, latLng.lng]
+  },
+
+  _getPosFromEvent: function (map, mouseEvent) {
+    var mapBoundingBoxClientRect = map.getContainer().getBoundingClientRect()
+    return {
+      x: mouseEvent.clientX - mapBoundingBoxClientRect.left,
+      y: mouseEvent.clientY - mapBoundingBoxClientRect.top
+    };
   },
 
   redraw: function (updating) {


### PR DESCRIPTION
We're using event.clientX and event.clientY when calculating the latlng and the pos, but those attributes represent the X and Y position of the event in relation to the viewport. This PR fixes that so that latlng and pos take into account the actual position of the map container.

cc: @fdansv 
