### PR TITLE
Fix paths

### DIFF
--- a/src/geo.js
+++ b/src/geo.js
@@ -43,14 +43,13 @@ module.exports = {
   },
 
   contains: function (boundingBox, feature) {
-    var self = this
     if (typeof feature.geometry.coordinates[0] === 'number') {
       return this.pointInBB(boundingBox, feature.geometry.coordinates)
     } else if (feature.geometry.type === 'MultiLineString' || feature.geometry.type === 'MultiPolygon') {
       var geometries = feature.geometry.coordinates
       for (var multipoly = 0; multipoly < geometries.length; multipoly++) {
         for (var poly = 0; poly < geometries[multipoly].length; poly++) {
-          return this.anyPointInBB(boundingBox,geometries[multipoly][poly])
+          return this.anyPointInBB(boundingBox, geometries[multipoly][poly])
         }
       }
     } else if (feature.geometry.type === 'LineString' || feature.geometry.type === 'Polygon') {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -350,9 +350,8 @@ Renderer.prototype = {
             selection.attr('class', 'markers').attr('cx', coords.x).attr('cy', coords.y)
           }
         }
-
       })
-    } 
+    }
     features.exit().remove()
     return features
   },

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -340,20 +340,14 @@ Renderer.prototype = {
           'Feature': 'path',
           'Point': 'circle'
         }[f.type])
-      }).attr('class', function (f) {
-        return {
-          'Feature': 'polygon',
-          'Point': 'markers'
-        }[f.type]
       }).each(function (f) {
+        var selection = d3.select(this)
         if (f.type === 'Feature') {
-          features.enter().append('path').attr('class', sym)
-          features.attr('d', self.path)
+          selection.attr('class', sym).attr('d', self.path)
         } else {
           if (f.coordinates[0]) {
             var coords = self.projection.apply(this, f.coordinates)
-            this.setAttribute('cx', coords.x)
-            this.setAttribute('cy', coords.y)
+            selection.attr('class', 'markers').attr('cx', coords.x).attr('cy', coords.y)
           }
         }
 


### PR DESCRIPTION
Fixes: adding paths several times.
Uses `d3.select` to be able to use/chain `attr` and avoid using setAttribute directly from nodes.

cc @fdansv 
