### PR TITLE
Makes styles easier to debug, properly sets comp-op symbolizer

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -245,31 +245,66 @@ Renderer.prototype = {
   styleForSymbolizer: function (symbolyzer, shaderName) {
     if (symbolyzer === 'polygon' || symbolyzer === 'line') {
       return {
-        'fill': function (d) { return d[shaderName]['polygon-fill'] || 'none' },
-        'fill-opacity': function (d) { return d[shaderName]['polygon-opacity'] },
-        'stroke': function (d) { return d[shaderName]['line-color'] },
-        'stroke-width': function (d) { return d[shaderName]['line-width'] },
-        'stroke-opacity': function (d) { return d[shaderName]['line-opacity'] },
-        'mix-blend-mode': function (d) { return d[shaderName]['comp-op'] || d[shaderName][symbolyzer + '-comp-op'] },
-        'stroke-dasharray': function (d) { return d[shaderName]['line-dasharray'] }
+        'fill': function (d) { 
+          return d[shaderName]['polygon-fill'] || 'none' 
+        },
+        'fill-opacity': function (d) { 
+          return d[shaderName]['polygon-opacity'] 
+        },
+        'stroke': function (d) { 
+          return d[shaderName]['line-color'] 
+        },
+        'stroke-width': function (d) { 
+          return d[shaderName]['line-width'] 
+        },
+        'stroke-opacity': function (d) { 
+          return d[shaderName]['line-opacity'] 
+        },
+        'mix-blend-mode': function (d) { 
+          var geometryType = 'marker';
+          if (d.geometry.type.toLowerCase().indexOf('line') > -1) geometryType = 'line';
+          else if (d.geometry.type.toLowerCase().indexOf('polygon') > -1) geometryType = 'polygon';
+          return d[shaderName]['comp-op'] || d[shaderName][geometryType + '-comp-op'] 
+        },
+        'stroke-dasharray': function (d) { 
+          return d[shaderName]['line-dasharray']
+           }
       }
     } else if (symbolyzer === 'markers') {
       return {
-        'fill': function (d) { return d[shaderName]['marker-fill'] || 'none' },
-        'fill-opacity': function (d) { return d[shaderName]['marker-fill-opacity'] },
-        'stroke': function (d) { return d[shaderName]['marker-line-color'] },
-        'stroke-opacity': function (d) { return d[shaderName]['marker-line-opacity'] },
-        'stroke-width': function (d) { return d[shaderName]['marker-line-width'] },
+        'fill': function (d) { 
+          return d[shaderName]['marker-fill'] || 'none' 
+        },
+        'fill-opacity': function (d) { 
+          return d[shaderName]['marker-fill-opacity'] 
+        },
+        'stroke': function (d) { 
+          return d[shaderName]['marker-line-color'] 
+        },
+        'stroke-opacity': function (d) { 
+          return d[shaderName]['marker-line-opacity'] 
+        },
+        'stroke-width': function (d) { 
+          return d[shaderName]['marker-line-width'] 
+        },
         'radius': function (d) {
           return d[shaderName]['marker-width'] / 2
         },
-        'mix-blend-mode': function (d) { return d[shaderName]['comp-op'] || d[shaderName]['marker-comp-op']},
-        'stroke-dasharray': function (d) { return d[shaderName]['line-dasharray'] }
+        'mix-blend-mode': function (d) { 
+          return d[shaderName]['comp-op'] || d[shaderName]['marker-comp-op']
+        },
+        'stroke-dasharray': function (d) { 
+          return d[shaderName]['line-dasharray']
+           }
       }
     } else if (symbolyzer === 'text') {
       return {
-        'fill': function (d) { return d[shaderName]['text-fill'] || 'none' },
-        'mix-blend-mode': function (d) { return d[shaderName]['comp-op'] || d[shaderName]['text-comp-op'] }
+        'fill': function (d) { 
+          return d[shaderName]['text-fill'] || 'none' 
+        },
+        'mix-blend-mode': function (d) { 
+          return d[shaderName]['comp-op'] || d[shaderName]['text-comp-op']
+           }
       }
     }
   },


### PR DESCRIPTION
The composite operation for some visualisations was failing because we weren't getting the symbolizer correctly. Internally, we treat lines and polygons with the same `polygon` symbolizer, so, when styling lines, the renderer was looking for `polygon-comp-op` instead of `line-comp-op`.

@javisantana cc @makella 
